### PR TITLE
removed supported tag from being added when support threshold hit

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -27,7 +27,7 @@ after_initialize do
 
 	  if(replies.length >= 1 && reply_word_count >= 500)
             topic.tags.delete needs_support_tag
-            topic.tags << supported_tag
+            # topic.tags << supported_tag
 	    supported = true
 	    newly_supported = true
           end


### PR DESCRIPTION
removed support tag from being added when word count threshold is reached due to the fact that the "supported" tag will be added from a separate plugin (discourse-solved)